### PR TITLE
Update holopin.yml with Hacktoberfest 2025 holobytes

### DIFF
--- a/.github/holopin.yml
+++ b/.github/holopin.yml
@@ -3,6 +3,9 @@ holobytes:
   - evolvingStickerId: cm1ti4x4c57560cjq2styaitm
     icon: avocado
     alias: hacktober-2024
+  - evolvingStickerId: cmg9s1kkz0046l204bc2k5k7e
+    icon: avocado
+    alias: hacktober-2025
 
 # First time contributor badge
 stickers:


### PR DESCRIPTION
This update adds new Holobytes for Hacktoberfest 2024 and Hacktoberfest 2025,  providing clear aliases for easier reference in automations.